### PR TITLE
adds missing install instructions (fixes #1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,3 +39,13 @@ add_dependencies(map_manager map_store_gencpp)
 target_link_libraries(map_manager uuid ${catkin_LIBRARIES})
 
 add_rostest(test/map_store.test)
+
+install(TARGETS map_saver
+	        map_manager
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(PROGRAMS scripts/add_map.py
+        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(DIRECTORY launch
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/src/map_manager.cpp
+++ b/src/map_manager.cpp
@@ -202,7 +202,7 @@ int main (int argc, char** argv)
   }
 
 
-  map_publisher = nh.advertise<nav_msgs::OccupancyGrid>("/map", 1, true);
+  map_publisher = nh.advertise<nav_msgs::OccupancyGrid>("map", 1, true);
   if (last_map != "")
   {
     nav_msgs::OccupancyGridConstPtr map;


### PR DESCRIPTION
This should fix the install problem and also removes the absolute namespace for the `map` topic.
