### PR TITLE
Add missing depend on uuid

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <build_depend>rosconsole</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rostest</build_depend>
+  <build_depend>uuid</build_depend>
   <build_depend>warehouse_ros</build_depend>
 
   <run_depend>message_runtime</run_depend>
@@ -25,6 +26,7 @@
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>uuid</run_depend>
   <run_depend>warehouse_ros</run_depend>
 </package>
 


### PR DESCRIPTION
`uuid` is clearly referenced in the `CMakeLists.txt` as well as `map_saver.cpp`. It obviously needs to be a build dependency, but must be a run dependency as well for the library to be present.

`uuid` is in rosdistro: https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml#L2569

It might make sense to make a separate rosdep entry for the devel package someday. Not sure where else `uuid` is used.

Thanks!
